### PR TITLE
更新两个div的class名，简介字符串添加strip处理

### DIFF
--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -147,7 +147,7 @@ class Crawler:
 
     def get_catalog_page(self, soup):
         Crawler.lock.acquire()
-        catalog_a = soup.find_all('div', class_='catalog_a')
+        catalog_a = soup.find_all('div', class_='catalog-a')
         for catalog in catalog_a:
             for tag in catalog.find_all('dl'):
                 catalog_dt = tag.find('dt')
@@ -187,9 +187,9 @@ class Crawler:
         url_tag = soup_tag.find('a', class_='blue')
         if url_tag and url_tag.string:
             brand['url'] = url_tag.string
-        desc_tag = soup_tag.find('div', class_='introduce_txt')
-        if desc_tag and desc_tag.string:
-            brand['desc'] = desc_tag.string
+        desc_tag = soup_tag.find('div', class_='introduce-txt')
+        if desc_tag and desc_tag.getText():
+            brand['desc'] = desc_tag.getText().strip()
         if brand.get('name'):
             self.__brand_save(brand)
 


### PR DESCRIPTION
首先lcsc官网的分页（catalog）上的div标签的class和品牌简介div标签的class名里的下划线变成了短横。其次，部分品牌简介里的div标签又套了个`<p>`标签，原来的`.string`属性会返回空，经实验改为`.getText()`方法。最后品牌简介获得后再添加`strip()`函数去掉前面和最后的空格和`\n`。